### PR TITLE
Allow using 'final' as a name in some contexts

### DIFF
--- a/cxxheaderparser/parser.py
+++ b/cxxheaderparser/parser.py
@@ -1250,7 +1250,16 @@ class CxxParser:
         return parts
 
     _pqname_start_tokens = (
-        {"auto", "decltype", "NAME", "operator", "template", "typename", "DBL_COLON"}
+        {
+            "auto",
+            "decltype",
+            "NAME",
+            "operator",
+            "template",
+            "typename",
+            "DBL_COLON",
+            "final",
+        }
         | _name_compound_start
         | _fundamentals
     )
@@ -1463,7 +1472,7 @@ class CxxParser:
             self.lex.return_tokens(toks[1:-1])
 
         # optional name
-        tok = self.lex.token_if("NAME")
+        tok = self.lex.token_if("NAME", "final")
         if tok:
             param_name = tok.value
 


### PR DESCRIPTION
- Strictly speaking, this fix will allow 'final' in some contexts where it isn't actually
  allowed. However, cxxheaderparser "will not reject all invalid C++ headers!" so this is ok
- Fixes #14