### PR TITLE
 Allow parser visitors to leverage the parser's state instead of creating their own stacks

### DIFF
--- a/cxxheaderparser/parser.py
+++ b/cxxheaderparser/parser.py
@@ -505,7 +505,8 @@ class CxxParser:
     def _on_empty_block_start(
         self, tok: LexToken, doxygen: typing.Optional[str]
     ) -> None:
-        self._push_state(EmptyBlockState)
+        state = self._push_state(EmptyBlockState)
+        self.visitor.on_empty_block_start(state)
 
     def _on_block_end(self, tok: LexToken, doxygen: typing.Optional[str]) -> None:
         old_state = self._pop_state()

--- a/cxxheaderparser/parser.py
+++ b/cxxheaderparser/parser.py
@@ -106,6 +106,8 @@ class CxxParser:
         else:
             self.debug_print = lambda fmt, *args: None
 
+        self.visitor.on_parse_start(self.state)
+
     #
     # State management
     #

--- a/cxxheaderparser/visitor.py
+++ b/cxxheaderparser/visitor.py
@@ -37,6 +37,11 @@ class CxxVisitor(Protocol):
     Defines the interface used by the parser to emit events
     """
 
+    def on_parse_start(self, state: NamespaceBlockState) -> None:
+        """
+        Called when parsing begins
+        """
+
     def on_pragma(self, state: State, content: Value) -> None:
         """
         Called once for each ``#pragma`` directive encountered

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -351,3 +351,29 @@ def test_warning_directive() -> None:
     data = parse_string(content, cleandoc=True)
 
     assert data == ParsedData()
+
+
+def test_empty_block() -> None:
+    """
+    Ensure the simple visitor doesn't break with an empty block
+    """
+    content = """
+      {
+          class X {};
+      }
+    """
+    data = parse_string(content, cleandoc=True)
+
+    assert data == ParsedData(
+        namespace=NamespaceScope(
+            classes=[
+                ClassScope(
+                    class_decl=ClassDecl(
+                        typename=PQName(
+                            segments=[NameSpecifier(name="X")], classkey="class"
+                        )
+                    )
+                )
+            ]
+        )
+    )


### PR DESCRIPTION
I started writing my own visitor and quickly realized that every parser is going to end up maintaining their own stacks of data, and there's already an implicit stack -- the parser state. This provides a mypy-friendly way of doing it. 

I'm not sure the type annotations are exactly right... I suspect there are definitely edge cases where this would fall apart. Open to improvements/suggestions.