### PR TITLE
Support multiple template declarations on a class or function

### DIFF
--- a/cxxheaderparser/types.py
+++ b/cxxheaderparser/types.py
@@ -514,6 +514,26 @@ class TemplateDecl:
     params: typing.List[TemplateParam] = field(default_factory=list)
 
 
+#: If no template, this is None. This is a TemplateDecl if this there is a single
+#: declaration:
+#:
+#: .. code-block:: c++
+#:
+#:    template <typename T>
+#:    struct C {};
+#:
+#: If there are multiple template declarations, then this is a list of
+#: declarations in the order that they're encountered:
+#:
+#: .. code-block:: c++
+#:
+#:    template<>
+#:    template<class U>
+#:    struct A<char>::C {};
+#:
+TemplateDeclTypeVar = typing.Union[None, TemplateDecl, typing.List[TemplateDecl]]
+
+
 @dataclass
 class TemplateInst:
     """
@@ -538,7 +558,7 @@ class ForwardDecl:
     """
 
     typename: PQName
-    template: typing.Optional[TemplateDecl] = None
+    template: TemplateDeclTypeVar = None
     doxygen: typing.Optional[str] = None
 
     #: Set if this is a forward declaration of an enum and it has a base
@@ -576,7 +596,7 @@ class ClassDecl:
     typename: PQName
 
     bases: typing.List[BaseClass] = field(default_factory=list)
-    template: typing.Optional[TemplateDecl] = None
+    template: TemplateDeclTypeVar = None
 
     explicit: bool = False
     final: bool = False
@@ -642,7 +662,7 @@ class Function:
     #: whatever the trailing return type was
     has_trailing_return: bool = False
 
-    template: typing.Optional[TemplateDecl] = None
+    template: TemplateDeclTypeVar = None
 
     #: Value of any throw specification for this function. The value omits the
     #: outer parentheses.

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2027,3 +2027,139 @@ def test_fwd_declared_method() -> None:
             ]
         )
     )
+
+
+def test_multiple_explicit_member_specialization() -> None:
+    content = """
+      template <>
+      template <>
+      inline Standard_CString
+      StdObjMgt_Attribute<TDF_TagSource>::Simple<Standard_Integer>::PName() const {
+        return "PDF_TagSource";
+      }
+    """
+    data = parse_string(content, cleandoc=True)
+
+    assert data == ParsedData(
+        namespace=NamespaceScope(
+            method_impls=[
+                Method(
+                    return_type=Type(
+                        typename=PQName(
+                            segments=[NameSpecifier(name="Standard_CString")]
+                        )
+                    ),
+                    name=PQName(
+                        segments=[
+                            NameSpecifier(
+                                name="StdObjMgt_Attribute",
+                                specialization=TemplateSpecialization(
+                                    args=[
+                                        TemplateArgument(
+                                            arg=Type(
+                                                typename=PQName(
+                                                    segments=[
+                                                        NameSpecifier(
+                                                            name="TDF_TagSource"
+                                                        )
+                                                    ]
+                                                )
+                                            )
+                                        )
+                                    ]
+                                ),
+                            ),
+                            NameSpecifier(
+                                name="Simple",
+                                specialization=TemplateSpecialization(
+                                    args=[
+                                        TemplateArgument(
+                                            arg=Type(
+                                                typename=PQName(
+                                                    segments=[
+                                                        NameSpecifier(
+                                                            name="Standard_Integer"
+                                                        )
+                                                    ]
+                                                )
+                                            )
+                                        )
+                                    ]
+                                ),
+                            ),
+                            NameSpecifier(name="PName"),
+                        ]
+                    ),
+                    parameters=[],
+                    inline=True,
+                    has_body=True,
+                    template=[TemplateDecl(), TemplateDecl()],
+                    const=True,
+                )
+            ]
+        )
+    )
+
+
+def test_member_class_template_specialization() -> None:
+    content = """
+      template <> // specialization of a member class template
+      template <class U>
+      struct A<char>::C {
+        void f();
+      };
+    """
+    data = parse_string(content, cleandoc=True)
+
+    assert data == ParsedData(
+        namespace=NamespaceScope(
+            classes=[
+                ClassScope(
+                    class_decl=ClassDecl(
+                        typename=PQName(
+                            segments=[
+                                NameSpecifier(
+                                    name="A",
+                                    specialization=TemplateSpecialization(
+                                        args=[
+                                            TemplateArgument(
+                                                arg=Type(
+                                                    typename=PQName(
+                                                        segments=[
+                                                            FundamentalSpecifier(
+                                                                name="char"
+                                                            )
+                                                        ]
+                                                    )
+                                                )
+                                            )
+                                        ]
+                                    ),
+                                ),
+                                NameSpecifier(name="C"),
+                            ],
+                            classkey="struct",
+                        ),
+                        template=[
+                            TemplateDecl(),
+                            TemplateDecl(
+                                params=[TemplateTypeParam(typekey="class", name="U")]
+                            ),
+                        ],
+                    ),
+                    methods=[
+                        Method(
+                            return_type=Type(
+                                typename=PQName(
+                                    segments=[FundamentalSpecifier(name="void")]
+                                )
+                            ),
+                            name=PQName(segments=[NameSpecifier(name="f")]),
+                            parameters=[],
+                            access="public",
+                        )
+                    ],
+                )
+            ]
+        )
+    )


### PR DESCRIPTION
- Fixes #20

I'm not really sure this is the most ergonomic way to represent this sort of weird thing, but at least if you had to parse it and try to make sense of it you could do something with the data that cxxheaderparser provides.