### PR TITLE
Added support for requires() constraints on methods that are not directly templated

### DIFF
--- a/cxxheaderparser/parser.py
+++ b/cxxheaderparser/parser.py
@@ -1980,7 +1980,7 @@ class CxxParser:
             elif tok_value == "requires":
                 method_template = method.template
                 if method_template is None:
-                    raise self._parse_error(tok)
+                    method_template = TemplateDecl([])
                 elif isinstance(method_template, list):
                     method_template = method_template[0]
                 method_template.raw_requires_post = self._parse_requires(tok)

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -835,15 +835,13 @@ def test_non_template_requires() -> None:
                             segments=[NameSpecifier(name="Payload")], classkey="struct"
                         ),
                         template=TemplateDecl(
-                            params=[TemplateTypeParam(
-                                typekey="class", name="T")]
+                            params=[TemplateTypeParam(typekey="class", name="T")]
                         ),
                     ),
                     methods=[
                         Method(
                             return_type=None,
-                            name=PQName(
-                                segments=[NameSpecifier(name="Payload")]),
+                            name=PQName(segments=[NameSpecifier(name="Payload")]),
                             parameters=[
                                 Parameter(
                                     type=Type(

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -6,6 +6,7 @@ from cxxheaderparser.types import (
     Concept,
     Function,
     FundamentalSpecifier,
+    Method,
     MoveReference,
     NameSpecifier,
     PQName,
@@ -805,6 +806,60 @@ def test_requires_paren() -> None:
                             ]
                         ),
                     ),
+                )
+            ]
+        )
+    )
+
+
+def test_non_template_requires() -> None:
+    content = """
+      template <class T>
+      struct Payload
+      {
+          constexpr Payload(T v)
+              requires(std::is_pod_v<T>)
+              : Value(v)
+          {
+          }
+      };
+    """
+    data = parse_string(content, cleandoc=True)
+
+    assert data == ParsedData(
+        namespace=NamespaceScope(
+            classes=[
+                ClassScope(
+                    class_decl=ClassDecl(
+                        typename=PQName(
+                            segments=[NameSpecifier(name="Payload")], classkey="struct"
+                        ),
+                        template=TemplateDecl(
+                            params=[TemplateTypeParam(
+                                typekey="class", name="T")]
+                        ),
+                    ),
+                    methods=[
+                        Method(
+                            return_type=None,
+                            name=PQName(
+                                segments=[NameSpecifier(name="Payload")]),
+                            parameters=[
+                                Parameter(
+                                    type=Type(
+                                        typename=PQName(
+                                            segments=[NameSpecifier(name="T")]
+                                        )
+                                    ),
+                                    name="v",
+                                )
+                            ],
+                            constexpr=True,
+                            has_body=True,
+                            access="public",
+                            constructor=True,
+                        )
+                    ],
                 )
             ]
         )


### PR DESCRIPTION
Currently, `cxxheaderparser` can only parse `requires()` constraints on methods which are also templated. However, under C++20, requires statements can also exist on un-templated methods in a templated class as well, this is usually used to replace `std::enable_if<>` function toggling.