### PR TITLE
Added support for template deduction guides

### DIFF
--- a/cxxheaderparser/simple.py
+++ b/cxxheaderparser/simple.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass, field
 from .types import (
     ClassDecl,
     Concept,
+    DeductionGuide,
     EnumDecl,
     Field,
     ForwardDecl,
@@ -122,6 +123,9 @@ class NamespaceScope:
 
     #: Child namespaces
     namespaces: typing.Dict[str, "NamespaceScope"] = field(default_factory=dict)
+
+    #: Deduction guides
+    deduction_guides: typing.List[DeductionGuide] = field(default_factory=list)
 
 
 Block = typing.Union[ClassScope, NamespaceScope]
@@ -316,6 +320,11 @@ class SimpleCxxVisitor:
 
     def on_class_end(self, state: SClassBlockState) -> None:
         pass
+
+    def on_deduction_guide(
+        self, state: SNonClassBlockState, guide: DeductionGuide
+    ) -> None:
+        state.user_data.deduction_guides.append(guide)
 
 
 def parse_string(

--- a/cxxheaderparser/types.py
+++ b/cxxheaderparser/types.py
@@ -896,3 +896,21 @@ class UsingAlias:
 
     #: Documentation if present
     doxygen: typing.Optional[str] = None
+
+
+@dataclass
+class DeductionGuide:
+    """
+    .. code-block:: c++
+
+    template <class T>
+    MyClass(T) -> MyClass(int);
+    """
+
+    #: Only constructors and destructors don't have a return type
+    result_type: typing.Optional[DecoratedType]
+
+    name: PQName
+    parameters: typing.List[Parameter]
+
+    doxygen: typing.Optional[str] = None

--- a/cxxheaderparser/visitor.py
+++ b/cxxheaderparser/visitor.py
@@ -9,6 +9,7 @@ else:
 
 from .types import (
     Concept,
+    DeductionGuide,
     EnumDecl,
     Field,
     ForwardDecl,
@@ -236,6 +237,13 @@ class CxxVisitor(Protocol):
         ``on_variable`` for each instance declared.
         """
 
+    def on_deduction_guide(
+        self, state: NonClassBlockState, guide: DeductionGuide
+    ) -> None:
+        """
+        Called when a deduction guide is encountered
+        """
+
 
 class NullVisitor:
     """
@@ -316,6 +324,11 @@ class NullVisitor:
         return None
 
     def on_class_end(self, state: ClassBlockState) -> None:
+        return None
+
+    def on_deduction_guide(
+        self, state: NonClassBlockState, guide: DeductionGuide
+    ) -> None:
         return None
 
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -5,6 +5,7 @@ from cxxheaderparser.types import (
     BaseClass,
     ClassDecl,
     DecltypeSpecifier,
+    DeductionGuide,
     Field,
     ForwardDecl,
     Function,
@@ -2157,6 +2158,89 @@ def test_member_class_template_specialization() -> None:
                             name=PQName(segments=[NameSpecifier(name="f")]),
                             parameters=[],
                             access="public",
+                        )
+                    ],
+                )
+            ]
+        )
+    )
+
+
+def test_template_deduction_guide() -> None:
+    content = """
+      template <class CharT, class Traits = std::char_traits<CharT>>
+      Error(std::basic_string_view<CharT, Traits>) -> Error<std::string>;
+    """
+    data = parse_string(content, cleandoc=True)
+
+    assert data == ParsedData(
+        namespace=NamespaceScope(
+            deduction_guides=[
+                DeductionGuide(
+                    result_type=Type(
+                        typename=PQName(
+                            segments=[
+                                NameSpecifier(
+                                    name="Error",
+                                    specialization=TemplateSpecialization(
+                                        args=[
+                                            TemplateArgument(
+                                                arg=Type(
+                                                    typename=PQName(
+                                                        segments=[
+                                                            NameSpecifier(name="std"),
+                                                            NameSpecifier(
+                                                                name="string"
+                                                            ),
+                                                        ]
+                                                    )
+                                                )
+                                            )
+                                        ]
+                                    ),
+                                )
+                            ]
+                        )
+                    ),
+                    name=PQName(segments=[NameSpecifier(name="Error")]),
+                    parameters=[
+                        Parameter(
+                            type=Type(
+                                typename=PQName(
+                                    segments=[
+                                        NameSpecifier(name="std"),
+                                        NameSpecifier(
+                                            name="basic_string_view",
+                                            specialization=TemplateSpecialization(
+                                                args=[
+                                                    TemplateArgument(
+                                                        arg=Type(
+                                                            typename=PQName(
+                                                                segments=[
+                                                                    NameSpecifier(
+                                                                        name="CharT"
+                                                                    )
+                                                                ]
+                                                            )
+                                                        )
+                                                    ),
+                                                    TemplateArgument(
+                                                        arg=Type(
+                                                            typename=PQName(
+                                                                segments=[
+                                                                    NameSpecifier(
+                                                                        name="Traits"
+                                                                    )
+                                                                ]
+                                                            )
+                                                        )
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                    ]
+                                )
+                            )
                         )
                     ],
                 )


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/language/class_template_argument_deduction

The parser was very close to being able to do this already, it just needed a bit of a peek to confirm. There might be a better way to do this, but it was the narrowest change I could come up with