### PR TITLE
Move non-template requires to the function

### DIFF
--- a/cxxheaderparser/parser.py
+++ b/cxxheaderparser/parser.py
@@ -1907,12 +1907,10 @@ class CxxParser:
         else:
             rtok = self.lex.token_if("requires")
             if rtok:
-                fn_template = fn.template
-                if fn_template is None:
+                # requires on a function must always be accompanied by a template
+                if fn.template is None:
                     raise self._parse_error(rtok)
-                elif isinstance(fn_template, list):
-                    fn_template = fn_template[0]
-                fn_template.raw_requires_post = self._parse_requires(rtok)
+                fn.raw_requires = self._parse_requires(rtok)
 
         if self.lex.token_if("ARROW"):
             self._parse_trailing_return_type(fn)
@@ -1978,12 +1976,7 @@ class CxxParser:
                     toks = self._consume_balanced_tokens(otok)[1:-1]
                 method.noexcept = self._create_value(toks)
             elif tok_value == "requires":
-                method_template = method.template
-                if method_template is None:
-                    raise self._parse_error(tok)
-                elif isinstance(method_template, list):
-                    method_template = method_template[0]
-                method_template.raw_requires_post = self._parse_requires(tok)
+                method.raw_requires = self._parse_requires(tok)
             else:
                 self.lex.return_token(tok)
                 break

--- a/cxxheaderparser/types.py
+++ b/cxxheaderparser/types.py
@@ -526,9 +526,6 @@ class TemplateDecl:
     #: template <typename T> requires ...
     raw_requires_pre: typing.Optional[Value] = None
 
-    #: template <typename T> int main() requires ...
-    raw_requires_post: typing.Optional[Value] = None
-
 
 #: If no template, this is None. This is a TemplateDecl if this there is a single
 #: declaration:
@@ -729,6 +726,13 @@ class Function:
     #: In the case of a conversion operator (such as 'operator bool'), this
     #: is the string "conversion" and the full Type is found in return_type
     operator: typing.Optional[str] = None
+
+    #: A requires constraint following the function declaration. If you need the
+    #: prior, look at TemplateDecl.raw_requires_pre. At the moment this is just
+    #: a raw value, if we interpret it in the future this will change.
+    #:
+    #: template <typename T> int main() requires ...
+    raw_requires: typing.Optional[Value] = None
 
 
 @dataclass


### PR DESCRIPTION
- Methods can have a requires() that refer to the class template without an explicit function template
- This is a breaking change, but since the values aren't parsed yet I can't imagine anyone is using it