### PR TITLE
ci: Update to Ubuntu 22.04

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -83,13 +83,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-13, ubuntu-20.04]
-        python_version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        os:
+        - windows-latest
+        - macos-13
+        - ubuntu-22.04
+        python_version:
+        - 3.7
+        - 3.8
+        - 3.9
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
         architecture: [x86, x64]
         exclude:
         - os: macos-13
           architecture: x86
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           architecture: x86
 
     steps:


### PR DESCRIPTION
- Remove Python 3.6 as it's unavailable for 22.04
- Add Python 3.13