### PR TITLE
Support __restrict keyword in parser

### DIFF
--- a/cxxheaderparser/lexer.py
+++ b/cxxheaderparser/lexer.py
@@ -125,6 +125,7 @@ class PlyLexer:
         "reinterpret_cast",
         "requires",
         "__restrict__",
+        "__restrict",
         "restrict",
         "return",
         "short",

--- a/cxxheaderparser/parser.py
+++ b/cxxheaderparser/parser.py
@@ -2432,7 +2432,7 @@ class CxxParser:
 
         while True:
             tok = self.lex.token_if(
-                "*", "const", "volatile", "__restrict__", "restrict", "("
+                "*", "const", "volatile", "__restrict__","__restrict", "restrict", "("
             )
             if not tok:
                 break
@@ -2449,7 +2449,7 @@ class CxxParser:
                 if not isinstance(dtype, (Pointer, Type)):
                     raise self._parse_error(tok)
                 dtype.volatile = True
-            elif tok.type in ("__restrict__", "restrict"):
+            elif tok.type in ("__restrict__","__restrict", "restrict"):
                 if not isinstance(dtype, (Pointer, Reference)):
                     raise self._parse_error(tok)
                 dtype.restrict = True
@@ -2524,7 +2524,7 @@ class CxxParser:
 
             # peek at the next token and see if it's a paren. If so, it might
             # be a nasty function pointer
-            if self.lex.token_peek_if("(", "__restrict__", "restrict"):
+            if self.lex.token_peek_if("(", "__restrict__","__restrict", "restrict"):
                 dtype = self._parse_cv_ptr_or_fn(dtype, nonptr_fn)
 
         return dtype

--- a/cxxheaderparser/parser.py
+++ b/cxxheaderparser/parser.py
@@ -2432,7 +2432,7 @@ class CxxParser:
 
         while True:
             tok = self.lex.token_if(
-                "*", "const", "volatile", "__restrict__","__restrict", "restrict", "("
+                "*", "const", "volatile", "__restrict__", "__restrict", "restrict", "("
             )
             if not tok:
                 break
@@ -2449,7 +2449,7 @@ class CxxParser:
                 if not isinstance(dtype, (Pointer, Type)):
                     raise self._parse_error(tok)
                 dtype.volatile = True
-            elif tok.type in ("__restrict__","__restrict", "restrict"):
+            elif tok.type in ("__restrict__", "__restrict", "restrict"):
                 if not isinstance(dtype, (Pointer, Reference)):
                     raise self._parse_error(tok)
                 dtype.restrict = True
@@ -2524,7 +2524,7 @@ class CxxParser:
 
             # peek at the next token and see if it's a paren. If so, it might
             # be a nasty function pointer
-            if self.lex.token_peek_if("(", "__restrict__","__restrict", "restrict"):
+            if self.lex.token_peek_if("(", "__restrict__", "__restrict", "restrict"):
                 dtype = self._parse_cv_ptr_or_fn(dtype, nonptr_fn)
 
         return dtype

--- a/tests/test_fn.py
+++ b/tests/test_fn.py
@@ -141,6 +141,7 @@ def test_fn_pointer_params() -> None:
       int fn3(int(*p));
       int fn4(int* __restrict__ p);
       int fn5(int& __restrict__ p);
+      int fn6(int* __restrict p);
     """
     data = parse_string(content, cleandoc=True)
 
@@ -229,6 +230,25 @@ def test_fn_pointer_params() -> None:
                             name="p",
                             type=Reference(
                                 ref_to=Type(
+                                    typename=PQName(
+                                        segments=[FundamentalSpecifier(name="int")]
+                                    )
+                                ),
+                                restrict=True,
+                            ),
+                        )
+                    ],
+                ),
+	        Function(
+                    return_type=Type(
+                        typename=PQName(segments=[FundamentalSpecifier(name="int")])
+                    ),
+                    name=PQName(segments=[NameSpecifier(name="fn6")]),
+                    parameters=[
+                        Parameter(
+                            name="p",
+                            type=Pointer(
+                                ptr_to=Type(
                                     typename=PQName(
                                         segments=[FundamentalSpecifier(name="int")]
                                     )

--- a/tests/test_fn.py
+++ b/tests/test_fn.py
@@ -239,7 +239,7 @@ def test_fn_pointer_params() -> None:
                         )
                     ],
                 ),
-	        Function(
+                Function(
                     return_type=Type(
                         typename=PQName(segments=[FundamentalSpecifier(name="int")])
                     ),


### PR DESCRIPTION
## Summary

Add support for the GNU-style `__restrict` qualifier.

The parser previously supported `restrict` and `__restrict__`, but failed when parsing declarations containing `__restrict`, which appears in Wine-generated headers.

## Changes

* Add `__restrict` to lexer keywords
* Handle `__restrict` in parser qualifier checks
* Add a regression test covering pointer parameters declared with `__restrict`

## Validation

* Added regression test in `tests/test_fn.py`
* `pytest tests/test_fn.py` passes
* Full test suite passes (`313 passed, 11 skipped`)
* The original parse failure caused by `__restrict` is resolved, and parsing now progresses further into the Wine-generated header.

Related to #118