### PR TITLE
Change extern to a bool from typing.Union[bool, str]

### DIFF
--- a/cxxheaderparser/types.py
+++ b/cxxheaderparser/types.py
@@ -758,7 +758,7 @@ class Function:
     attributes: typing.List[Attribute] = field(default_factory=list)
 
     constexpr: bool = False
-    extern: typing.Union[bool, str] = False
+    extern: bool = False
     static: bool = False
     inline: bool = False
     deleted: bool = False
@@ -900,7 +900,7 @@ class Variable:
     value: typing.Optional[Value] = None
 
     constexpr: bool = False
-    extern: typing.Union[bool, str] = False
+    extern: bool = False
     static: bool = False
     inline: bool = False
 


### PR DESCRIPTION
Currently Function and Variable have type hinting for extern -> `extern: typing.Union[bool, str] = False` 
I propose changing this to just be `extern: bool`

It seems like this was added so that if I do something like:
`extern "C++" double pi;` extern will hold `"C++"` instead of true. But, this behavior hasn't been implemented yet so it seems like extern should stay as just being a bool until it is. 

At [parser.py:2710](https://github.com/robotpy/cxxheaderparser/blob/18e24a23211f2fcbad3e87276b91176fa2d7aa1f/cxxheaderparser/parser.py#L2710) it says `# TODO: store linkage` so it seems clear to me that this behavior has not yet been implemented. 

I haven't been able to find any way that `extern` could ever be a `str` and it is messing up my [ty](https://github.com/astral-sh/ty) checks when I try to assign a boolean variable the result of `Variable.extern`.